### PR TITLE
Increase amount of XP needed for higher levels

### DIFF
--- a/components/progress-tracker.tsx
+++ b/components/progress-tracker.tsx
@@ -193,7 +193,7 @@ export function ProgressTracker() {
       case 10:
         return 4500
       default:
-        return 4500 + (level - 10) * 1000
+        return 50 * level * (level - 1)
     }
   }
 


### PR DESCRIPTION
Increase the amount of XP needed for higher levels to avoid fast leveling up, like affected by multipliers